### PR TITLE
style: README logo 替换为 SVG，恢复导航栏主站跳转

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Vitepress
 node_modules
 .vitepress/dist
 .vitepress/cache
+
+# Trash
+.DS_Store

--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -16,7 +16,7 @@ export const shared = defineConfig({
   ],
 
   themeConfig: {
-    logo: { src: '/logo.ico', link: MAIN_SITE_URL },
+    logo: '/logo.svg',
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/SeaLantern-Studio/SeaLantern' },

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,3 +1,34 @@
 import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import { MAIN_SITE_URL } from '../urls'
 
-export default DefaultTheme
+/** 将 .VPNavBarTitle 内的链接 href 强制指向主站 */
+function patchTitleLink() {
+  const link = document.querySelector('.VPNavBarTitle a') as HTMLAnchorElement | null
+  if (link && link.href !== MAIN_SITE_URL) {
+    link.href = MAIN_SITE_URL
+  }
+}
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp() {
+    if (typeof document === 'undefined') return
+
+    const observer = new MutationObserver(patchTitleLink)
+    const tryObserve = () => {
+      const navbar = document.querySelector('.VPNavBar')
+      if (navbar) {
+        patchTitleLink()
+        observer.observe(navbar, { childList: true, subtree: true })
+      } else {
+        requestAnimationFrame(tryObserve)
+      }
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', tryObserve)
+    } else {
+      tryObserve()
+    }
+  },
+} satisfies Theme

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="public/logo.ico" alt="logo" width="120" height="120">
+<img src="public/logo.svg" alt="logo" width="120" height="120">
 
 # Sea Lantern Docs
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="public/logo.ico" alt="logo" width="120" height="120">
+<img src="public/logo.svg" alt="logo" width="120" height="120">
 
 # Sea Lantern Docs
 

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,12 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#aaddff"/>
+      <stop offset="100%" stop-color="#66bbff"/>
+    </linearGradient>
+  </defs>
+  <!-- 主体 (无投影，适合做应用图标) -->
+  <rect x="0" y="0" width="512" height="512" rx="128" fill="url(#grad)" />
+  <!-- 内部方块 -->
+  <rect x="176" y="176" width="160" height="160" rx="48" fill="white" fill-opacity="0.85"/>
+</svg>


### PR DESCRIPTION
- README 中英文版 logo 从 .ico 替换为 .svg
- 导航栏 logo 替换为 SVG
- 恢复 NavBar 标题链接 DOM patch（VitePress logo 不支持 link 属性）
- .gitignore 添加 .DS_Store

## Summary by Sourcery

将文档中的徽标切换为 SVG，并恢复导航栏标题指向主站点的链接，同时添加一条简单的忽略规则。

Bug Fixes（错误修复）:
- 恢复导航栏标题链接，使其在 VitePress 徽标功能受限的情况下，仍能稳定指向主站点。

Enhancements（功能增强）:
- 将 README 和站点导航栏中的徽标资源从 ICO 替换为 SVG，以提升显示质量。

Documentation（文档）:
- 更新中文版和英文版 README，使其使用新的 SVG 徽标资源。

Chores（日常维护）:
- 将 `.DS_Store` 添加到 `.gitignore` 中，避免提交 macOS 的元数据文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch documentation logos to SVG and restore navbar title linking to the main site while adding a small ignore rule.

Bug Fixes:
- Restore navbar title link so it consistently points to the main site despite VitePress logo limitations.

Enhancements:
- Replace README and site navbar logo assets from ICO to SVG for improved display quality.

Documentation:
- Update Chinese and English READMEs to use the new SVG logo asset.

Chores:
- Add .DS_Store to .gitignore to avoid committing macOS metadata files.

</details>