### PR TITLE
docs(install): 同步 Ubuntu PPA 安装说明

### DIFF
--- a/en/download.md
+++ b/en/download.md
@@ -41,6 +41,20 @@ Arch Linux users can install via AUR, for example:
 yay -S sealantern
 ```
 
+### Ubuntu PPA (Community-maintained)
+
+Ubuntu users can install via PPA:
+
+```bash
+sudo add-apt-repository ppa:brianeee7878/sealantern
+sudo apt update
+sudo apt install sea-lantern-ppa-updater
+```
+
+Supports Ubuntu 20.04 LTS, 22.04 LTS, and 24.04 LTS.
+
+This PPA is community-maintained and not an official release channel. If you run into issues, use the DEB package above.
+
 ## System Requirements
 
 - Windows 10+ / macOS 10.15+ / Linux (glibc 2.31+)

--- a/en/getting-started.md
+++ b/en/getting-started.md
@@ -16,6 +16,10 @@ Sea Lantern uses the WebView2 runtime and **requires Windows 10 (version 1909+) 
 
 Go to the [Download page](/en/download) to get the installer for your operating system. Double-click to install.
 
+Ubuntu users can also install via PPA (see the Linux section on the download page).
+
+Arch Linux users can install via AUR (see the Linux section on the download page).
+
 ## 2. Get a Server JAR
 
 You need a Minecraft server JAR file to create a server. If you don't have one yet, check the [Server JAR Guide](/en/server-jar) to download one.

--- a/zh-tw/download.md
+++ b/zh-tw/download.md
@@ -41,6 +41,20 @@ Arch Linux 使用者可透過 AUR 安裝，例如：
 yay -S sealantern
 ```
 
+### Ubuntu PPA（社群維護）
+
+Ubuntu 使用者可透過 PPA 快速安裝：
+
+```bash
+sudo add-apt-repository ppa:brianeee7878/sealantern
+sudo apt update
+sudo apt install sea-lantern-ppa-updater
+```
+
+支援 Ubuntu 20.04 LTS、22.04 LTS 與 24.04 LTS。
+
+該 PPA 為社群維護渠道，不屬於官方發布渠道；若遇到問題請改用上方 DEB 安裝包。
+
 ## 系統需求
 
 - Windows 10+ / macOS 10.15+ / Linux (glibc 2.31+)

--- a/zh-tw/getting-started.md
+++ b/zh-tw/getting-started.md
@@ -16,6 +16,10 @@ Sea Lantern 使用 WebView2 執行環境，**要求 Windows 10（版本 1909 及
 
 前往 [下載頁面](/zh-tw/download) 取得適合您作業系統的安裝包，雙擊執行即可完成安裝。
 
+Ubuntu 使用者也可使用 PPA 安裝（見下載頁 Linux 小節）。
+
+Arch Linux 使用者可透過 AUR 安裝（見下載頁 Linux 小節）。
+
 ## 2. 取得伺服端核心
 
 您需要一個 Minecraft 伺服端 JAR 檔案來建立伺服器。如果您還沒有，請參考 [伺服端核心取得](/zh-tw/server-jar) 頁面下載。

--- a/zh/download.md
+++ b/zh/download.md
@@ -41,6 +41,20 @@ Arch Linux 用户可通过 AUR 安装，例如：
 yay -S sealantern
 ```
 
+### Ubuntu PPA（社区维护）
+
+Ubuntu 用户可通过 PPA 快速安装：
+
+```bash
+sudo add-apt-repository ppa:brianeee7878/sealantern
+sudo apt update
+sudo apt install sea-lantern-ppa-updater
+```
+
+支持 Ubuntu 20.04 LTS、22.04 LTS 和 24.04 LTS。
+
+该 PPA 为社区维护渠道，不属于官方发布渠道；如遇问题请改用上方 DEB 安装包。
+
 ## 系统要求
 
 - Windows 10+ / macOS 10.15+ / Linux (glibc 2.31+)

--- a/zh/getting-started.md
+++ b/zh/getting-started.md
@@ -16,6 +16,10 @@ Sea Lantern 使用 WebView2 运行时，**要求 Windows 10（版本 1909 及以
 
 前往 [下载页面](/zh/download) 获取适合你操作系统的安装包，双击运行即可完成安装。
 
+Ubuntu 用户也可以使用 PPA 安装（见下载页 Linux 小节）。
+
+Arch Linux 用户可通过 AUR 安装（见下载页 Linux 小节）。
+
 ## 2. 获取服务端核心
 
 你需要一个 Minecraft 服务端 JAR 文件来创建服务器。如果你还没有，请参考 [核心获取](/zh/server-jar) 页面下载。


### PR DESCRIPTION
## 变更说明

同步 SeaLantern 主仓库 PR [#296](https://github.com/SeaLantern-Studio/SeaLantern/pull/296) 的 PPA 安装信息到 docs 站点。

## 具体改动

- 在下载页新增 Ubuntu PPA 安装说明（简中/英文/繁中）
- 在快速开始补充 Linux 安装入口提示：
  - Ubuntu：PPA 安装
  - Arch Linux：AUR 安装
- 标注 PPA 为社区维护渠道，并提示问题回退到 DEB 包

## 影响范围

- zh/download.md
- en/download.md
- zh-tw/download.md
- zh/getting-started.md
- en/getting-started.md
- zh-tw/getting-started.md

## 验证

- 本地执行 `pnpm build` 通过
