### PR TITLE
feat: 添加 ContributorsGrid 组件以显示 GitHub 贡献者

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -20,8 +20,8 @@ export const en = defineConfig({
 
     contributorsGrid: {
       contributionsLabel: 'contributions',
-      loading: 'Loading contributors…',
-      errorGeneric: 'Failed to load contributors. Please try again later.',
+      loading: 'Loading contributors card…',
+      errorGeneric: 'Failed to load contributors card. Please try again later.',
       errorRateLimit: 'GitHub rate limit reached. Please try again in a few minutes.',
       errorNotFound: 'Contributors could not be found for this repository.',
       errorTooManyRequests: 'Too many requests to GitHub. Please wait a moment and try again.',

--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -17,6 +17,15 @@ export const en = defineConfig({
       message: 'Released under the GPL-3.0 License',
       copyright: '© 2024-present SeaLantern Studio',
     },
+
+    contributorsGrid: {
+      contributionsLabel: 'contributions',
+      loading: 'Loading contributors…',
+      errorGeneric: 'Failed to load contributors. Please try again later.',
+      errorRateLimit: 'GitHub rate limit reached. Please try again in a few minutes.',
+      errorNotFound: 'Contributors could not be found for this repository.',
+      errorTooManyRequests: 'Too many requests to GitHub. Please wait a moment and try again.',
+    },
   },
 })
 

--- a/.vitepress/config/zh-tw.ts
+++ b/.vitepress/config/zh-tw.ts
@@ -18,6 +18,15 @@ export const zhTw = defineConfig({
       copyright: '© 2024-present SeaLantern Studio',
     },
 
+    contributorsGrid: {
+      contributionsLabel: '次貢獻',
+      loading: '載入貢獻者中…',
+      errorGeneric: '載入貢獻者失敗，請稍後重試。',
+      errorRateLimit: '已達到 GitHub 請求限制，請稍後再試。',
+      errorNotFound: '未找到該儲存庫的貢獻者。',
+      errorTooManyRequests: '請求過於頻繁，請稍等片刻後重試。',
+    },
+
     docFooter: {
       prev: '上一頁',
       next: '下一頁',

--- a/.vitepress/config/zh-tw.ts
+++ b/.vitepress/config/zh-tw.ts
@@ -20,8 +20,8 @@ export const zhTw = defineConfig({
 
     contributorsGrid: {
       contributionsLabel: '次貢獻',
-      loading: '載入貢獻者中…',
-      errorGeneric: '載入貢獻者失敗，請稍後重試。',
+      loading: '載入貢獻者卡片中…',
+      errorGeneric: '載入貢獻者卡片失敗，請稍後重試。',
       errorRateLimit: '已達到 GitHub 請求限制，請稍後再試。',
       errorNotFound: '未找到該儲存庫的貢獻者。',
       errorTooManyRequests: '請求過於頻繁，請稍等片刻後重試。',

--- a/.vitepress/config/zh.ts
+++ b/.vitepress/config/zh.ts
@@ -18,6 +18,15 @@ export const zh = defineConfig({
       copyright: '© 2024-present SeaLantern Studio',
     },
 
+    contributorsGrid: {
+      contributionsLabel: '次贡献',
+      loading: '加载贡献者中…',
+      errorGeneric: '加载贡献者失败，请稍后重试。',
+      errorRateLimit: '已达到 GitHub 请求限制，请稍后再试。',
+      errorNotFound: '未找到该仓库的贡献者。',
+      errorTooManyRequests: '请求过于频繁，请稍等片刻后重试。',
+    },
+
     docFooter: {
       prev: '上一页',
       next: '下一页',

--- a/.vitepress/config/zh.ts
+++ b/.vitepress/config/zh.ts
@@ -20,8 +20,8 @@ export const zh = defineConfig({
 
     contributorsGrid: {
       contributionsLabel: '次贡献',
-      loading: '加载贡献者中…',
-      errorGeneric: '加载贡献者失败，请稍后重试。',
+      loading: '加载贡献者卡片中…',
+      errorGeneric: '加载贡献者卡片失败，请稍后重试。',
       errorRateLimit: '已达到 GitHub 请求限制，请稍后再试。',
       errorNotFound: '未找到该仓库的贡献者。',
       errorTooManyRequests: '请求过于频繁，请稍等片刻后重试。',

--- a/.vitepress/theme/components/ContributorsGrid.vue
+++ b/.vitepress/theme/components/ContributorsGrid.vue
@@ -12,7 +12,15 @@ const props = withDefaults(defineProps<{
 
 const loading = ref(true)
 const error = ref('')
-const contributors = ref<any[]>([])
+interface Contributor {
+  id: number
+  login: string
+  avatar_url: string
+  html_url: string
+  contributions: number
+}
+
+const contributors = ref<Contributor[]>([])
 
 async function fetchContributors() {
   loading.value = true
@@ -51,7 +59,15 @@ async function fetchContributors() {
       throw new Error('Failed to load contributors.')
     }
 
-    contributors.value = data.slice(0, props.max)
+    const mapped: Contributor[] = data.map((d: any) => ({
+      id: d.id,
+      login: d.login,
+      avatar_url: d.avatar_url,
+      html_url: d.html_url,
+      contributions: typeof d.contributions === 'number' ? d.contributions : 0,
+    }))
+
+    contributors.value = mapped.slice(0, props.max)
   } catch (e: any) {
     console.error('[ContributorsGrid] Error while loading contributors', e)
     error.value = e?.message || 'Failed to load contributors.'

--- a/.vitepress/theme/components/ContributorsGrid.vue
+++ b/.vitepress/theme/components/ContributorsGrid.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const props = withDefaults(defineProps<{
+  repo: string
+  perPage?: number
+  max?: number
+  cacheTTL?: number
+}>(), {
+  perPage: 100,
+  max: 100,
+  cacheTTL: 60 * 60 * 1000,
+})
+
+const loading = ref(true)
+const error = ref('')
+const contributors = ref<any[]>([])
+
+const cacheKey = `github-contributors:${props.repo}:${props.perPage}:${props.max}`
+
+function loadCache() {
+  try {
+    const cached = localStorage.getItem(cacheKey)
+    if (!cached) return null
+    const { timestamp, data } = JSON.parse(cached)
+    if (Date.now() - timestamp > props.cacheTTL) {
+      localStorage.removeItem(cacheKey)
+      return null
+    }
+    return data
+  } catch {
+    return null
+  }
+}
+
+function saveCache(data: any[]) {
+  try {
+    localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data }))
+  } catch {}
+}
+
+async function fetchContributors() {
+  const cached = loadCache()
+  if (cached) {
+    contributors.value = cached.slice(0, props.max)
+    loading.value = false
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+  try {
+    const url = `https://api.github.com/repos/${props.repo}/contributors?per_page=${props.perPage}`
+    const res = await fetch(url, { headers: { Accept: 'application/vnd.github.v3+json' } })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json()
+    if (!Array.isArray(data)) throw new Error('Invalid response')
+    contributors.value = data.slice(0, props.max)
+    saveCache(contributors.value)
+  } catch (e: any) {
+    error.value = e.message || String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchContributors)
+</script>
+
+<template>
+  <div class="sl-contrib">
+    <div v-if="loading" class="sl-contrib__message">Loading contributors…</div>
+    <div v-else-if="error" class="sl-contrib__message">{{ error }}</div>
+    <div v-else class="sl-contrib__card">
+      <div class="sl-contrib__grid">
+        <a
+          v-for="c in contributors"
+          :key="c.id"
+          :href="c.html_url"
+          class="sl-contrib__item"
+          target="_blank"
+          rel="noopener noreferrer"
+          :title="`${c.login} — ${c.contributions} contributions`"
+        >
+          <img :src="c.avatar_url" :alt="c.login" class="sl-contrib__avatar" />
+          <span class="sl-contrib__name">{{ c.login }}</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sl-contrib__message {
+  color: var(--vp-c-text-2);
+  margin: 8px 0 12px;
+}
+.sl-contrib__card {
+  background-color: var(--vp-c-bg-soft);
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+}
+.sl-contrib__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 4px;
+  align-items: center;
+}
+.sl-contrib__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  padding: 4px 2px;
+  border-radius: 6px;
+  transition: background-color 0.2s;
+}
+.sl-contrib__item:hover {
+  background-color: var(--vp-c-bg-mute);
+}
+.sl-contrib__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.sl-contrib__name {
+  margin-top: 2px;
+  font-size: 11px;
+  max-width: 64px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--vp-c-text-1);
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -72,7 +72,9 @@ function initTitleLinkEnhancer() {
 
 export default {
   extends: DefaultTheme,
-  enhanceApp({ app }) {
+  enhanceApp(ctx) {
+    DefaultTheme.enhanceApp?.(ctx)
+    const { app } = ctx
     initTitleLinkEnhancer()
     app.component('ContributorsGrid', ContributorsGrid)
   },

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
 import { MAIN_SITE_URL } from '../urls'
+import ContributorsGrid from './components/ContributorsGrid.vue'
 
 /** 将 .VPNavBarTitle 内的链接 href 强制指向主站 */
 function patchTitleLink() {
@@ -71,8 +72,9 @@ function initTitleLinkEnhancer() {
 
 export default {
   extends: DefaultTheme,
-  enhanceApp() {
+  enhanceApp({ app }) {
     initTitleLinkEnhancer()
+    app.component('ContributorsGrid', ContributorsGrid)
   },
 } satisfies Theme
 

--- a/.vitepress/theme/vitepress.d.ts
+++ b/.vitepress/theme/vitepress.d.ts
@@ -1,0 +1,16 @@
+import 'vitepress'
+
+declare module 'vitepress' {
+  namespace DefaultTheme {
+    interface Config {
+      contributorsGrid?: {
+        contributionsLabel?: string
+        loading?: string
+        errorGeneric?: string
+        errorRateLimit?: string
+        errorNotFound?: string
+        errorTooManyRequests?: string
+      }
+    }
+  }
+}

--- a/en/contributor.md
+++ b/en/contributor.md
@@ -2,6 +2,6 @@
 
 Thanks to all contributors of Sea Lantern.
 
-[![Contributors](https://sealentern-contributors.sb4893.workers.dev/)](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors)
+<ContributorsGrid repo="SeaLantern-Studio/SeaLantern" />
 
-See [GitHub Contributors](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors).
+See [GitHub Contributors](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors) for the full graph on GitHub.

--- a/zh-tw/contributor.md
+++ b/zh-tw/contributor.md
@@ -2,6 +2,6 @@
 
 感謝所有為 Sea Lantern 做出貢獻的開發者。
 
-[![Contributors](https://sealentern-contributors.sb4893.workers.dev/)](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors)
+<ContributorsGrid repo="SeaLantern-Studio/SeaLantern" />
 
 詳見 [GitHub Contributors](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors)。

--- a/zh/contributor.md
+++ b/zh/contributor.md
@@ -2,6 +2,6 @@
 
 感谢所有为 Sea Lantern 做出贡献的开发者。
 
-[![Contributors](https://sealentern-contributors.sb4893.workers.dev/)](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors)
+<ContributorsGrid repo="SeaLantern-Studio/SeaLantern" />
 
 详见 [GitHub Contributors](https://github.com/SeaLantern-Studio/SeaLantern/graphs/contributors)。


### PR DESCRIPTION
看原本的贡献者卡片没了，就vibe了一个，有错误请指正。
原本想用 [contrib.rocks](https://contrib.rocks/) 的但是太糊了

## 由 Sourcery 提供的摘要

向 VitePress 主题中新增一个可复用的贡献者网格组件，并将其集成到贡献者页面中。

新功能：
- 引入一个 `ContributorsGrid` Vue 组件，用于获取并在自适应网格中展示 GitHub 仓库的贡献者。

文档：
- 在所有本地化的贡献者页面中，用新的 `ContributorsGrid` 组件替换外部贡献者图片嵌入，并对指向完整 GitHub 贡献者图的链接进行说明和澄清。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a reusable contributors grid component to the VitePress theme and integrate it into the contributor pages.

New Features:
- Introduce a ContributorsGrid Vue component that fetches and displays GitHub repository contributors in a responsive grid.

Documentation:
- Replace the external contributors image embed with the new ContributorsGrid component across all localized contributor pages and clarify the link to the full GitHub contributors graph.

</details>