### PR TITLE
[补充内容] 添加对于由于代理等网络配置问题导致SL无法启动的问题说明

### DIFF
--- a/en/faq.md
+++ b/en/faq.md
@@ -10,7 +10,7 @@ Check if you have `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` environment variab
 
 SeaLantern is built on Tauri and essentially acts as a browser accessing localhost. Therefore, system configurations related to the network stack (such as proxy or firewall settings) may affect the normal operation of SeaLantern.
 
-If you encounter other similar issues on SeaLantern, such as `Connection Refused`, please check the relevant configurations first.
+If you encounter other similar issues with SeaLantern, such as `Connection Refused`, please check the relevant configurations first.
 
 ## Server Won't Start
 

--- a/en/faq.md
+++ b/en/faq.md
@@ -1,5 +1,17 @@
 # FAQ
 
+## SeaLantern Won't Start
+
+### Window Doesn't Appear or Is Blank, Only Taskbar Icon Shows
+
+Possible proxy configuration conflict.
+
+Check if you have `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` environment variables set. If so, clear them.
+
+SeaLantern is built on Tauri and essentially acts as a browser accessing localhost. Therefore, system configurations related to the network stack (such as proxy or firewall settings) may affect the normal operation of SeaLantern.
+
+If you encounter other similar issues on SeaLantern, such as `Connection Refused`, please check the relevant configurations first.
+
 ## Server Won't Start
 
 ### "Java not found"

--- a/zh-tw/faq.md
+++ b/zh-tw/faq.md
@@ -1,5 +1,17 @@
 # 常見問題
 
+## SeaLantern 無法啟動
+
+### 視窗不出現或空白，只有工作列圖示
+
+可能為代理設定衝突。
+
+請檢查是否有設定 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 等環境變數。如有設定，請將其清空。
+
+SeaLantern 基於 Tauri 實現，本質上是一個存取 localhost 的瀏覽器，因此涉及網路堆疊的系統設定（如代理伺服器、防火牆設定）均可能影響 SeaLantern 的正常運作。
+
+如果遇到其他類似的 SeaLantern 問題，例如 `Connection Refused`，請優先檢查相關設定。
+
 ## 無法啟動伺服器
 
 ### 提示「Java 未找到」

--- a/zh/faq.md
+++ b/zh/faq.md
@@ -1,5 +1,17 @@
 # 常见问题
 
+## SeaLantern 无法启动
+
+### 窗口不出现或空白，只有任务栏图标
+
+可能为代理设置冲突。
+
+请检查是否设置了 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 等环境变量。如有设置，请将其置空。
+
+SeaLantern 基于 Tauri 实现，本质上是一个访问 localhost 的浏览器，因此涉及网络栈的系统配置（如代理服务器、防火墙设置）均可能影响 SeaLantern 的正常运行。
+
+如果遇到其他类似的 SeaLantern 问题，例如 `Connection Refused`，请优先检查相关配置。
+
 ## 无法启动服务器
 
 ### 提示「Java 未找到」


### PR DESCRIPTION
在FAQ中添加了对：由于配置了代理服务器、防火墙而导致的SeaLantern无法启动 问题的说明。

此PR用于解决 SeaLantern-Studio/SeaLantern#558 。

## Summary by Sourcery

Documentation:
- 添加英文、简体中文和繁体中文的常见问题条目，说明代理、防火墙和相关网络设置如何导致 SeaLantern 无法启动或无法正常显示，以及如何解决这些问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add FAQ entries in English, Simplified Chinese, and Traditional Chinese describing how proxy, firewall, and related network settings can prevent SeaLantern from starting or displaying correctly, and how to resolve these issues.

</details>